### PR TITLE
Fix broken links in Chapter_03.ipynb

### DIFF
--- a/code/Chapter 03/Chapter_03.ipynb
+++ b/code/Chapter 03/Chapter_03.ipynb
@@ -46,8 +46,8 @@
     {
       "cell_type": "code",
       "source": [
-        "!wget https://raw.githubusercontent.com/nceder/qpb4e/main/code/ch01-05/shape.py\n",
-        "!wget https://raw.githubusercontent.com/nceder/qpb4e/main/code/ch01-05/wo.py\n",
+        "!wget https://raw.githubusercontent.com/nceder/qpb4e/main/code/Chapter%2003/shape.py\n",
+        "!wget https://raw.githubusercontent.com/nceder/qpb4e/main/code/Chapter%2003/wo.py\n",
         "!touch empty_file\n",
         "! echo \"This is myfile1.txt\" > myfile1.txt\n",
         "! echo \"This is myfile2.txt\" > myfile2.txt\n"


### PR DESCRIPTION
The following URLs in the example file for chapter 3 fail to resolve (404):

https://raw.githubusercontent.com/nceder/qpb4e/main/code/ch01-05/shape.py https://raw.githubusercontent.com/nceder/qpb4e/main/code/ch01-05/wo.py

The directory `code/ch01-05` does not exist in the repo. Paths have been corrected to `code/Chapter%2003`.