### PR TITLE
Chapter 3: Fix imp import 

### DIFF
--- a/code/Chapter 03/Chapter_03.ipynb
+++ b/code/Chapter 03/Chapter_03.ipynb
@@ -2346,7 +2346,7 @@
     {
       "cell_type": "code",
       "source": [
-        "import imp\n",
+        "import importlib as imp\n",
         "imp.reload(wo)"
       ],
       "metadata": {

--- a/code/Chapter 03/chapter_03.py
+++ b/code/Chapter 03/chapter_03.py
@@ -445,7 +445,7 @@ wo.words_occur()
 
 """
 
-import imp
+import importlib as imp
 imp.reload(wo)
 
 """#3.4 Object oriented programming


### PR DESCRIPTION
`imp` is removed since version 3.12 in favor of `importlib`. Current import throws `ModuleNotFoundError` on versions >= 3.12

### Action
Replaced the imp import with importlib 